### PR TITLE
Add index path of node to toggle event parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "gulp-eslint": "^1.0.0",
     "gulp-open": "^1.0.0",
     "gulp-util": "^3.0.7",
+    "immutability-helper": "^2.7.0",
     "istanbul": "^0.4.5",
     "istanbul-instrumenter-loader": "^0.2.0",
     "karma": "^1.7.0",

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -14,11 +14,11 @@ class TreeNode extends React.Component {
     }
 
     onClick() {
-        const {node, onToggle} = this.props;
+        const {node, onToggle, indexPath} = this.props;
         const {toggled} = node;
 
         if (onToggle) {
-            onToggle(node, !toggled);
+            onToggle(node, !toggled, indexPath);
         }
     }
 
@@ -90,7 +90,7 @@ class TreeNode extends React.Component {
     }
 
     renderChildren(decorators) {
-        const {animations, decorators: propDecorators, node, style} = this.props;
+        const {animations, decorators: propDecorators, node, style, indexPath} = this.props;
 
         if (node.loading) {
             return this.renderLoading(decorators);
@@ -109,7 +109,8 @@ class TreeNode extends React.Component {
                                                           decorators={propDecorators}
                                                           key={child.id || index}
                                                           node={child}
-                                                          style={style}/>
+                                                          style={style}
+                                                          indexPath={indexPath.concat(['children', index])}/>
                 )}
             </ul>
         );
@@ -144,7 +145,11 @@ TreeNode.propTypes = {
         PropTypes.object,
         PropTypes.bool
     ]).isRequired,
-    onToggle: PropTypes.func
+    onToggle: PropTypes.func,
+    indexPath: PropTypes.arrayOf(PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number
+    ])).isRequired
 };
 
 export default TreeNode;

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -152,4 +152,8 @@ TreeNode.propTypes = {
     ])).isRequired
 };
 
+TreeNode.defaultProps = {
+    indexPath: []
+};
+
 export default TreeNode;

--- a/src/components/treebeard.js
+++ b/src/components/treebeard.js
@@ -12,10 +12,12 @@ class TreeBeard extends React.Component {
     render() {
         const {animations, decorators, data: propsData, onToggle, style} = this.props;
         let data = propsData;
+        let startFromObject = false;
 
         // Support Multiple Root Nodes. Its not formally a tree, but its a use-case.
         if (!Array.isArray(data)) {
             data = [data];
+            startFromObject = true;
         }
         return (
             <ul style={style.tree.base}
@@ -26,7 +28,8 @@ class TreeBeard extends React.Component {
                               key={node.id || index}
                               node={node}
                               onToggle={onToggle}
-                              style={style.tree.node}/>
+                              style={style.tree.node}
+                              indexPath={startFromObject ? [] : [index]}/>
                 )}
             </ul>
         );


### PR DESCRIPTION
Instead of mutating node state directly by node reference, I've added an index path to third parameter of toggle function (it's an array of index) to lookup clicked node and mutate it indirectly.

Example:
`
onToggle(node, toggled, indexPath) {
  // indexPath -> ['children', 0, 'children', 1]
}
`